### PR TITLE
Add function to read uint256[] array from immutable args

### DIFF
--- a/src/Clone.sol
+++ b/src/Clone.sol
@@ -34,6 +34,28 @@ contract Clone {
         }
     }
 
+    /// @notice Reads a uint256 array stored in the immutable args.
+    /// @param argOffset The offset of the arg in the packed data
+    /// @param arrLen Amount of elements in the array
+    /// @return arr The array
+    function _getArgUint256Array(uint256 argOffset, uint64 arrLen)
+        internal
+        pure
+      returns (uint256[] memory arr)
+    {
+      uint256 offset = _getImmutableArgsOffset();
+      uint256 el;
+      arr = new uint256[](arrLen);
+      for (uint64 i = 0; i < arrLen; i++) {
+        assembly {
+          // solhint-disable-next-line no-inline-assembly
+          el := calldataload(add(add(offset, argOffset), mul(i, 32)))
+        }
+        arr[i] = el;
+      }
+      return arr;
+    }
+
     /// @notice Reads an immutable arg with type uint64
     /// @param argOffset The offset of the arg in the packed data
     /// @return arg The arg value

--- a/src/Clone.sol
+++ b/src/Clone.sol
@@ -36,7 +36,7 @@ contract Clone {
 
     /// @notice Reads a uint256 array stored in the immutable args.
     /// @param argOffset The offset of the arg in the packed data
-    /// @param arrLen Amount of elements in the array
+    /// @param arrLen Number of elements in the array
     /// @return arr The array
     function _getArgUint256Array(uint256 argOffset, uint64 arrLen)
         internal


### PR DESCRIPTION
- Adds a function to read uint256[] array from immutable args. 
- The function expects an additional arg: array length (number of elements in the array).