### PR TITLE
add 'payable' to support more kinds of clones

### DIFF
--- a/src/ClonesWithImmutableArgs.sol
+++ b/src/ClonesWithImmutableArgs.sol
@@ -15,7 +15,7 @@ library ClonesWithImmutableArgs {
     /// @return instance The address of the created clone
     function clone(address implementation, bytes memory data)
         internal
-        returns (address instance)
+        returns (address payable instance)
     {
         // unrealistic for memory ptr or data length to exceed 256 bits
         unchecked {


### PR DESCRIPTION
support clones with fallback ETH receive() function by adding `payable` to address return param