### PR TITLE
Allow to pass non-zero msg.value directly to proxy constructor

### DIFF
--- a/src/ExampleCloneFactory.sol
+++ b/src/ExampleCloneFactory.sol
@@ -18,9 +18,9 @@ contract ExampleCloneFactory {
         uint256 param2,
         uint64 param3,
         uint8 param4
-    ) external returns (ExampleClone clone) {
+    ) external payable returns (ExampleClone clone) {
         bytes memory data = abi.encodePacked(param1, param2, param3, param4);
-        clone = ExampleClone(address(implementation).clone(data));
+        clone = ExampleClone(address(implementation).clone(data, msg.value));
     }
     
     function createClone2(
@@ -28,9 +28,9 @@ contract ExampleCloneFactory {
         uint256 param2,
         uint64 param3,
         uint8 param4
-    ) external returns (ExampleClone clone) {
+    ) external payable returns (ExampleClone clone) {
         bytes memory data = abi.encodePacked(param1, param2, param3, param4);
-        clone = ExampleClone(address(implementation).clone2(data));
+        clone = ExampleClone(address(implementation).clone2(data, msg.value));
     }
 
     function addressOfClone2(
@@ -49,9 +49,9 @@ contract ExampleCloneFactory {
         uint64 param3,
         uint8 param4,
         bytes32 salt
-    ) external returns (ExampleClone clone) {
+    ) external payable returns (ExampleClone clone) {
         bytes memory data = abi.encodePacked(param1, param2, param3, param4);
-        clone = ExampleClone(address(implementation).clone3(data, salt));
+        clone = ExampleClone(address(implementation).clone3(data, salt, msg.value));
     }
 
     function addressOfClone3(bytes32 salt) external view returns (address) {

--- a/src/test/ExampleCloneFactory.t.sol
+++ b/src/test/ExampleCloneFactory.t.sol
@@ -62,6 +62,24 @@ contract ExampleCloneFactoryTest is DSTest {
         assertEq(clone.param4(), param4);
     }
 
+    function testCorrectness_clone_value(
+        address param1,
+        uint256 param2,
+        uint64 param3,
+        uint8 param4
+    ) public {
+        ExampleClone clone = factory.createClone{ value: 1 wei }(
+            param1,
+            param2,
+            param3,
+            param4
+        );
+        assertEq(clone.param1(), param1);
+        assertEq(clone.param2(), param2);
+        assertEq(clone.param3(), param3);
+        assertEq(clone.param4(), param4);
+    }
+
     function testCorrectness_clone2(
         address param1,
         uint256 param2,
@@ -69,6 +87,24 @@ contract ExampleCloneFactoryTest is DSTest {
         uint8 param4
     ) public {
         ExampleClone clone = factory.createClone2(
+            param1,
+            param2,
+            param3,
+            param4
+        );
+        assertEq(clone.param1(), param1);
+        assertEq(clone.param2(), param2);
+        assertEq(clone.param3(), param3);
+        assertEq(clone.param4(), param4);
+    }
+
+    function testCorrectness_clone2_value(
+        address param1,
+        uint256 param2,
+        uint64 param3,
+        uint8 param4
+    ) public {
+        ExampleClone clone = factory.createClone2{ value: 1 wei }(
             param1,
             param2,
             param3,
@@ -88,6 +124,27 @@ contract ExampleCloneFactoryTest is DSTest {
         bytes32 salt
     ) public {
         ExampleClone clone = factory.createClone3(
+            param1,
+            param2,
+            param3,
+            param4,
+            salt
+        );
+        assertEq(clone.param1(), param1);
+        assertEq(clone.param2(), param2);
+        assertEq(clone.param3(), param3);
+        assertEq(clone.param4(), param4);
+        assertEq(address(clone), factory.addressOfClone3(salt));
+    }
+
+    function testCorrectness_clone3_value(
+        address param1,
+        uint256 param2,
+        uint64 param3,
+        uint8 param4,
+        bytes32 salt
+    ) public {
+        ExampleClone clone = factory.createClone3{ value: 1 wei }(
             param1,
             param2,
             param3,


### PR DESCRIPTION
Passing some value before proxy creation requires proxy address extra computation, transfering value after creation triggers both proxy and implementation calls.

I see create3 proxy contract already supports `msg.value`:
```
CALLDATASIZE
RETURNDATASIZE
RETURNDATASIZE
CALLDATACOPY
CALLDATASIZE
RETURNDATASIZE
CALLVALUE
CREATE
```